### PR TITLE
refactor(*): apply new lint rule set up and lint fix on new rules

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,19 +1,7 @@
 version: "2"
 plugins:
   eslint:
-    enabled: true
-    channel: "eslint-4"
-    config: 
-      config: .eslintrc.json
-    checks:
-      # compat is not a codeclimeate supported eslint plugin
-      compat/compat:
-        enabled: false
-      # indent rules on codeclimate seem to be different from
-      # the local ones - probably because cc uses an older version
-      # of eslint
-      indent:
-        enabled: false
+    enabled: false
 exclude_patterns:
   - ".github/"
   - "test/"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.idea
 .nyc_output
 npm-debug.log
 node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - ./cc-test-reporter before-build
 
 script:
- - 'if test `node --version | cut -c 2,3` = 13; then npm run check; else npm test; fi'
+  - "if test `node --version | cut -c 2,3` = 13; then npm run check; else npm test; fi"
 
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -14,21 +14,21 @@ orientation.
 Examples of behavior that contributes to creating a positive environment
 include:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic
   address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Our Responsibilities

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ## What's this then?
+
 A micro module that helps you require (versions of) modules
 that might not be there.
 
@@ -6,73 +7,77 @@ Useful to test for the availability of _optional_ and _peer_ dependencies
 before working with them.
 
 ## Example
+
 So you made the typescript compiler (v2) an optional dependency.
 But you just want to keep running if it ain't there.
 
 Do this:
 
 ```javascript
-const tryRequire = require('semver-try-require');
+const tryRequire = require("semver-try-require");
 
 // import typescript if there's a version >= 2 available
-const typescript = tryRequire('typescript', '>=2');
+const typescript = tryRequire("typescript", ">=2");
 
 // now you can test if typescript is actually there
-const lProgram = 'const cube = x => x*x*x; console.log(cube(42))';
+const lProgram = "const cube = x => x*x*x; console.log(cube(42))";
 
 if (typescript !== false) {
-    console.log(
-        typescript.transpileModule(lProgram, {}).outputText
-    );
-    // Result:
-    //   var cube = function (x) { return x * x * x; };
-    //   console.log(cube(42));
+  console.log(typescript.transpileModule(lProgram, {}).outputText);
+  // Result:
+  //   var cube = function (x) { return x * x * x; };
+  //   console.log(cube(42));
 } else {
-    // typescript >=2 not found - use fallback
-    console.log(
-        lProgram
-    );
-    // Result:
-    //    const cube = x => x*x*x; console.log(cube(42))
+  // typescript >=2 not found - use fallback
+  console.log(lProgram);
+  // Result:
+  //    const cube = x => x*x*x; console.log(cube(42))
 }
 ```
 
 ## Signature
+
 ### `pModulename`
+
 The name of the module to resolve.
 
 ### `pSemVer`
+
 A semantic version (range). Optional.
 
 ### return value
+
 The (resolved) module identified by pModuleName if:
+
 - it is available, and
 - it satisfies the semantic version range specified by pSemVer
 
 returns false in all other cases
 
-
 ## History
+
 This module started to try a few non-run-of-the-mill things with the
 npm registry (deprecate, beta publishing, renaming). The tryRequire
 function in
 [dependency-cruiser ](https://github.com/sverweij/dependency-cruiser)
 seemed like a good candidate as it was not a thing that'd be unique
 to dependency-cruiser, and would probably be easier to maintain on its
-own anyway. I named it `tigerclaws-try-require` until I realized the 
+own anyway. I named it `tigerclaws-try-require` until I realized the
 _semver_ check was what distinguished it from the other try-require
 like npm modules out there.
 
 [dependency-cruiser](https://github.com/sverweij/dependency-cruiser)
-now uses semver-try-require in the [transpiler wrappers](https://github.com/sverweij/dependency-cruiser/tree/develop/src/extract/transpile) 
-and it enables it to cruise typescript, coffeescript and livescript 
-code without having to ship the heavy duty compilers for these 
+now uses semver-try-require in the [transpiler wrappers](https://github.com/sverweij/dependency-cruiser/tree/develop/src/extract/transpile)
+and it enables it to cruise typescript, coffeescript and livescript
+code without having to ship the heavy duty compilers for these
 languages.
 
 ## License
+
 [MIT](LICENSE)
 
 ## Badge & flair section
+
 [![Build Status](https://travis-ci.org/sverweij/semver-try-require.svg?branch=master)](https://travis-ci.org/sverweij/semver-try-require)
 [![npm stable version](https://img.shields.io/npm/v/semver-try-require.svg)](https://npmjs.com/package/semver-try-require)
 [![total downloads on npm](https://img.shields.io/npm/dt/semver-try-require.svg?maxAge=2591999)](https://npmjs.com/package/semver-try-require)

--- a/package.json
+++ b/package.json
@@ -26,22 +26,29 @@
   },
   "devDependencies": {
     "eslint": "6.8.0",
-    "eslint-config-standard": "14.1.0",
+    "eslint-config-moving-meadow": "1.0.0",
+    "eslint-config-prettier": "6.10.0",
+    "eslint-plugin-budapestian": "1.0.0",
     "eslint-plugin-import": "2.20.1",
+    "eslint-plugin-mocha": "6.3.0",
     "eslint-plugin-node": "11.0.0",
-    "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-security": "1.4.0",
-    "eslint-plugin-standard": "4.0.1",
+    "eslint-plugin-unicorn": "15.0.1",
     "jest": "25.1.0",
     "npm-run-all": "4.1.5",
+    "prettier": "1.19.1",
     "upem": "3.1.2"
   },
   "scripts": {
     "check": "npm-run-all --parallel lint test",
     "check:full": "npm-run-all --parallel check check:outdated",
     "check:outdated": "npm outdated",
-    "lint": "eslint src test",
-    "lint:fix": "eslint --fix src test",
+    "lint": "npm-run-all lint:eslint prettier",
+    "lint:eslint": "eslint src test",
+    "lint:fix": "npm-run-all lint:fix:eslint prettier:fix",
+    "lint:fix:eslint": "eslint --fix src test",
+    "prettier": "prettier --loglevel warn --check {src,test}/\\*\\*/\\*.{js,json} \\*.{md,yml,json} types/\\*",
+    "prettier:fix": "prettier --loglevel warn --write {src,test}/\\*\\*/\\*.{js,json} \\*.{md,yml,json} types/\\*",
     "scm:push": "run-p --aggregate-output scm:push:*",
     "scm:push:github": "run-p --aggregate-output scm:push:github:*",
     "scm:push:github:commits": "git push",
@@ -91,10 +98,7 @@
   },
   "types": "types/index.d.ts",
   "eslintConfig": {
-    "extends": "standard",
-    "plugins": [
-      "security"
-    ],
+    "extends": "moving-meadow",
     "env": {
       "node": true,
       "es6": true
@@ -114,18 +118,10 @@
         "warn",
         4
       ],
-      "security/detect-unsafe-regex": "error",
-      "security/detect-buffer-noassert": "error",
-      "security/detect-child-process": "error",
-      "security/detect-disable-mustache-escape": "error",
-      "security/detect-eval-with-expression": "error",
-      "security/detect-no-csrf-before-method-override": "error",
-      "security/detect-non-literal-fs-filename": "off",
-      "security/detect-non-literal-regexp": "error",
-      "security/detect-non-literal-require": "error",
-      "security/detect-object-injection": "error",
-      "security/detect-possible-timing-attacks": "error",
-      "security/detect-pseudoRandomBytes": "error"
+      "security/detect-non-literal-require": "off",
+      "global-require": "off",
+      "import/no-dynamic-require": "off",
+      "import/order": "warn"
     }
   },
   "eslintIgnore": [

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-const path = require('path')
-const semver = require('semver')
+const path = require("path");
+const semver = require("semver");
 
 /**
  * returns the (resolved) module identified by pModuleName:
@@ -14,31 +14,23 @@ const semver = require('semver')
  *                              or false
  */
 module.exports = (pModuleName, pSemVer) => {
-  let lRetval = false
+  let lReturnValue = false;
 
   try {
-    lRetval = require(pModuleName)
+    lReturnValue = require(pModuleName);
 
     if (
       Boolean(pSemVer) &&
-        !semver.satisfies(
-          semver.coerce(
-            require(path.join(pModuleName, 'package.json')).version
-          ).version,
-          pSemVer
-        )
+      !semver.satisfies(
+        semver.coerce(require(path.join(pModuleName, "package.json")).version)
+          .version,
+        pSemVer
+      )
     ) {
-      lRetval = false
+      lReturnValue = false;
     }
-  } catch (e) {
-    lRetval = false
+  } catch (pError) {
+    lReturnValue = false;
   }
-  return lRetval
-}
-
-/*
-  eslint
-    global-require: 0,
-    security/detect-non-literal-require: 0
-    import/no-dynamic-require: 0
- */
+  return lReturnValue;
+};

--- a/test/beta-fixture/package.json
+++ b/test/beta-fixture/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "beta-fixture",
-    "description": "test if release candidates are correctly detected as well",
-    "version": "3.0.0-beta-0",
-    "main": "./index.js"
+  "name": "beta-fixture",
+  "description": "test if release candidates are correctly detected as well",
+  "version": "3.0.0-beta-0",
+  "main": "./index.js"
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,74 +1,42 @@
-'use strict'
+const semver = require("semver");
+const tryRequire = require("../src");
+const rcFixture = require("../test/rc-fixture");
+const betaFixture = require("../test/rc-fixture");
 
-const semver = require('semver')
-const tryRequire = require('../src')
-const rcFixture = require('../test/rc-fixture')
-const betaFixture = require('../test/rc-fixture')
+describe("tryRequire", () => {
+  test("returns false for unresolvable modules", () => {
+    expect(tryRequire("thispackage-is-not-there")).toBe(false);
+  });
 
-describe('tryRequire', () => {
-  test('returns false for unresolvable modules', () => {
-    expect(
-      tryRequire('thispackage-is-not-there')
-    ).toBe(false)
-  })
+  test("returns the module if it is resolvable", () => {
+    expect(tryRequire("semver")).toEqual(semver);
+  });
 
-  test('returns the module if it is resolvable', () => {
-    expect(
-      tryRequire('semver')
-    ).toEqual(semver)
-  })
+  test("returns the module if it is resolvable and satisfies specified semver", () => {
+    expect(tryRequire("semver", ">=5.0.0 <7.0.0")).toEqual(semver);
+  });
 
-  test(
-    'returns the module if it is resolvable and satisfies specified semver',
-    () => {
-      expect(
-        tryRequire('semver', '>=5.0.0 <7.0.0')
-      ).toEqual(semver)
-    }
-  )
+  test("returns the module if it is resolvable and satisfies specified semver (with rc postfix)", () => {
+    expect(tryRequire("../test/rc-fixture", ">=2.0.0 <4.0.0")).toEqual(
+      rcFixture
+    );
+  });
 
-  test(
-    'returns the module if it is resolvable and satisfies specified semver (with rc postfix)',
-    () => {
-      expect(
-        tryRequire('../test/rc-fixture', '>=2.0.0 <4.0.0')
-      ).toEqual(rcFixture)
-    }
-  )
+  test("returns false if it is resolvable but does not satisfy specified semver (with rc postfix)", () => {
+    expect(tryRequire("../test/rc-fixture", ">=2.0.0 <3.0.0")).toEqual(false);
+  });
 
-  test(
-    'returns false if it is resolvable but does not satisfy specified semver (with rc postfix)',
-    () => {
-      expect(
-        tryRequire('../test/rc-fixture', '>=2.0.0 <3.0.0')
-      ).toEqual(false)
-    }
-  )
+  test("returns the module if it is resolvable and satisfies specified semver (with beta postfix)", () => {
+    expect(tryRequire("../test/beta-fixture", ">=2.0.0 <4.0.0")).toEqual(
+      betaFixture
+    );
+  });
 
-  test(
-    'returns the module if it is resolvable and satisfies specified semver (with beta postfix)',
-    () => {
-      expect(
-        tryRequire('../test/beta-fixture', '>=2.0.0 <4.0.0')
-      ).toEqual(betaFixture)
-    }
-  )
+  test("returns false if it is resolvable but does not satisfy specified semver (with beta postfix)", () => {
+    expect(tryRequire("../test/beta-fixture", ">=2.0.0 <3.0.0")).toEqual(false);
+  });
 
-  test(
-    'returns false if it is resolvable but does not satisfy specified semver (with beta postfix)',
-    () => {
-      expect(
-        tryRequire('../test/beta-fixture', '>=2.0.0 <3.0.0')
-      ).toEqual(false)
-    }
-  )
-
-  test(
-    "returns false if it is resolvable but doesn't satisfy the specified semver",
-    () => {
-      expect(
-        tryRequire('semver', '<5.0.0')
-      ).toEqual(false)
-    }
-  )
-})
+  test("returns false if it is resolvable but doesn't satisfy the specified semver", () => {
+    expect(tryRequire("semver", "<5.0.0")).toEqual(false);
+  });
+});

--- a/test/rc-fixture/package.json
+++ b/test/rc-fixture/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "rc-fixture",
-    "description": "test if release candidates are correctly detected as well",
-    "version": "3.0.0-rc",
-    "main": "./index.js"
+  "name": "rc-fixture",
+  "description": "test if release candidates are correctly detected as well",
+  "version": "3.0.0-rc",
+  "main": "./index.js"
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,3 @@
-
-declare const tryRequire:
 /**
  * returns the (resolved) module identified by pModuleName:
  * - if it is available, and
@@ -12,5 +10,8 @@ declare const tryRequire:
  * @return {object}             the (resolved) module identified by pModuleName
  *                              or false
  */
-(pModuleName: string, pSemVer?: string) => boolean | any;
+declare const tryRequire: (
+  pModuleName: string,
+  pSemVer?: string
+) => boolean | any;
 export = tryRequire;


### PR DESCRIPTION
## Description

- See title
- also switches code style from standardjs to prettier
- note: put `import/order` on `warn` as it fails on windows (erroneously)

## Motivation and Context

- Unifies setup over several of my projects making maintenance easier

## How Has This Been Tested?

- running lint
- green ci


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [x] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
