### PR TITLE
feature: support sub modules

### DIFF
--- a/src/extract-root-module-name.js
+++ b/src/extract-root-module-name.js
@@ -1,0 +1,24 @@
+/* eslint-disable security/detect-non-literal-regexp */
+/**
+ * returns the module name that likely contains the package.json
+ *
+ * @param {string} pModuleName module name string as you'd require it
+ */
+
+const LOCAL_MODULE_RE = /^[.]{1,2}($|\/.*)/g;
+const ABSOLUTE_MODULE_RE = /^\/.*/g;
+
+const PACKAGE_RE = "[^/]+";
+const SCOPED_PACKAGE_RE = "@[^/]+(/[^/]+)";
+const ROOT_MODULE_RE = new RegExp(`^(${SCOPED_PACKAGE_RE}|${PACKAGE_RE})`, "g");
+
+module.exports = function extractRootModuleName(pModuleName) {
+  if (
+    pModuleName.match(LOCAL_MODULE_RE) ||
+    pModuleName.match(ABSOLUTE_MODULE_RE)
+  ) {
+    return pModuleName;
+  } else {
+    return (pModuleName.match(ROOT_MODULE_RE) || []).shift();
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,11 @@
 const path = require("path");
 const semver = require("semver");
+const extractRootModuleName = require("./extract-root-module-name");
+
+function getVersion(pModuleName) {
+  return require(path.join(extractRootModuleName(pModuleName), "package.json"))
+    .version;
+}
 
 /**
  * returns the (resolved) module identified by pModuleName:
@@ -21,11 +27,7 @@ module.exports = (pModuleName, pSemVer) => {
 
     if (
       Boolean(pSemVer) &&
-      !semver.satisfies(
-        semver.coerce(require(path.join(pModuleName, "package.json")).version)
-          .version,
-        pSemVer
-      )
+      !semver.satisfies(semver.coerce(getVersion(pModuleName)).version, pSemVer)
     ) {
       lReturnValue = false;
     }

--- a/test/extract-root-module-name.spec.js
+++ b/test/extract-root-module-name.spec.js
@@ -1,0 +1,46 @@
+const extractRootModuleName = require("../src/extract-root-module-name");
+
+describe("extract-root-module-name", () => {
+  it("returns the local module name when passed that (same folder)", () => {
+    expect(extractRootModuleName("./hoi-pippeloi")).toBe("./hoi-pippeloi");
+    expect(extractRootModuleName("./hoi/pippeloi")).toBe("./hoi/pippeloi");
+  });
+  it("returns the local module name when passed that (one ore more folders up)", () => {
+    expect(extractRootModuleName("../hoi-pippeloi")).toBe("../hoi-pippeloi");
+    expect(extractRootModuleName("../hoi/pippeloi")).toBe("../hoi/pippeloi");
+    expect(extractRootModuleName("../../hoi/pippeloi")).toBe(
+      "../../hoi/pippeloi"
+    );
+  });
+  it("returns . when passed current folder", () => {
+    expect(extractRootModuleName(".")).toBe(".");
+    expect(extractRootModuleName("./")).toBe("./");
+  });
+  it("returns .. when passed one folder up", () => {
+    expect(extractRootModuleName("..")).toBe("..");
+    expect(extractRootModuleName("../")).toBe("../");
+  });
+  it("returns the module name when passed an absolute module name", () => {
+    expect(extractRootModuleName("/")).toBe("/");
+    expect(extractRootModuleName("/Users/root/hello")).toBe(
+      "/Users/root/hello"
+    );
+  });
+  it("returns undefined when passed an empty string", () => {
+    expect(extractRootModuleName("")).toBeUndefined();
+  });
+  it("returns the module name when there's no special shizzle", () => {
+    expect(extractRootModuleName("yodash")).toBe("yodash");
+  });
+  it("returns the root module when passed a submodule", () => {
+    expect(extractRootModuleName("yodash/ship-ahoi")).toBe("yodash");
+  });
+  it("returns the scope + module when passed scoped module", () => {
+    expect(extractRootModuleName("@yodash/yodash")).toBe("@yodash/yodash");
+  });
+  it("returns the scope + module when passed submodule of a scoped module", () => {
+    expect(extractRootModuleName("@yodash/yodash/alaaf")).toBe(
+      "@yodash/yodash"
+    );
+  });
+});

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines-per-function */
 const semver = require("semver");
 const tryRequire = require("../src");
 const rcFixture = require("../test/rc-fixture");


### PR DESCRIPTION
## Description, Motivation and Context

semver-try-require wasn't able to correctly handle module inclusions of submodules. E.g. `wowdash` would work, as would `@wowsers/wowdash`, but `wowdash/do-magic` would return false when a version range was put in (as it would look at the version number in `wowdash/do-magic` instead of the one in `wowdash`). This pull request enables that functionality.

## How Has This Been Tested?

- [x] additional unit tests
- [x] automated non-regression tests + green ci

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
