### PR TITLE
bugfix: enables importing modules that don't have an export default statement

### DIFF
--- a/dist/try-import.mjs
+++ b/dist/try-import.mjs
@@ -24,7 +24,7 @@ export default async function tryImport(pModuleName, pSemanticVersion) {
     let lReturnValue = false;
     try {
         const lModule = await import(pModuleName);
-        lReturnValue = lModule.default;
+        lReturnValue = lModule.default ? lModule.default : lModule;
         if (pSemanticVersion) {
             const lVersion = getVersion(pModuleName);
             const lCoerced = coerce(lVersion);

--- a/src/node_modules/no-default-export/main.mjs
+++ b/src/node_modules/no-default-export/main.mjs
@@ -1,0 +1,6 @@
+function compile() {
+
+}
+const something = "something else";
+
+export {compile, something}

--- a/src/node_modules/no-default-export/package.json
+++ b/src/node_modules/no-default-export/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "no-default-export",
+  "description": "test whether packages without a default export get detected as well",
+  "version": "3.0.0",
+  "exports": {
+    ".": {
+        "import": "./main.mjs"
+    }
+  }
+  
+}

--- a/src/try-import.mts
+++ b/src/try-import.mts
@@ -50,6 +50,7 @@ function getVersion(pModuleName: string): string {
   return lManifest.version;
 }
 
+// eslint-disable-next-line complexity
 export default async function tryImport(
   pModuleName: string,
   pSemanticVersion?: string
@@ -58,7 +59,7 @@ export default async function tryImport(
 
   try {
     const lModule = await import(pModuleName);
-    lReturnValue = lModule.default;
+    lReturnValue = lModule.default ? lModule.default : lModule;
 
     if (pSemanticVersion) {
       const lVersion = getVersion(pModuleName);

--- a/src/try-import.spec.mts
+++ b/src/try-import.spec.mts
@@ -1,5 +1,6 @@
-import { strictEqual, deepStrictEqual } from "node:assert";
+import { strictEqual, deepStrictEqual } from "assert";
 import semver from "semver";
+import * as noDefaultExportMock from "no-default-export";
 import tryImport from "./try-import.mjs";
 
 import betaMock from "beta";
@@ -12,6 +13,10 @@ describe("tryImport", () => {
 
   it("returns the module if it is resolvable", async () => {
     deepStrictEqual(await tryImport("semver"), semver);
+  });
+
+  it("returns the module if it is resolvable and doesn't have a default export", async () => {
+    strictEqual(await tryImport("no-default-export"), noDefaultExportMock);
   });
 
   it("returns the module if it is resolvable and satisfies specified semver", async () => {


### PR DESCRIPTION
## Description

- enables importing modules that don't have an export default statement

## Motivation and Context

As that tends to happen, that needs to be supported.

## How Has This Been Tested?

- [x] green ci
- [x] additional unit test


## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation only change
- [ ] Refactor (non-breaking change which fixes an issue without changing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] :book:

  - My change doesn't require a documentation update, or ...
  - it _does_ and I have updated it

- [x] :balance_scale:
  - The contribution will be subject to [The MIT license](../LICENSE), and I'm OK with that.
  - The contribution is my own original work.
  - I am ok with the stuff in [**CONTRIBUTING.md**](./CONTRIBUTING.md).
